### PR TITLE
Specify timeout to allow longer than 10 seconds

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -38,14 +38,14 @@ class LoginFailedException(Exception):
 
 class MonarchMoney(object):
 
-  def __init__(self, session_file: str=SESSION_FILE) -> None:
+  def __init__(self, session_file: str=SESSION_FILE, timeout: int=10) -> None:
     self._cookies = None
     self._headers = {
       'Client-Platform': 'web',
     }
     self._session_file = session_file
     self._token = None
-    self._timeout = 10
+    self._timeout = timeout
 
   @property
   def timeout(self) -> int:


### PR DESCRIPTION
When trying to retrieve 1000 transactions, I get a timeout error due to the 10 second timeout. This PR adds an optional keyword param to specify a custom timeout.