### PR TITLE
add token param to authorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ This may throw a `RequireMFAException`.  If it does, you'll need to get a multi-
 mm.multi_factor_authenticate(email, password, multi_factor_code)
 ```
 
+Alternatively, you can provide the MFA Secret Key. The MFA Secret Key is found when setting up the MFA in Monarch Money by going to Settings -> Security -> Enable MFA -> and copy the "Two-factor text code". Then provide it in the login() method:
+```python
+await nm.login(
+        email=email,
+        password=password,
+        save_session=False,
+        use_saved_session=False,
+        mfa_secret_key=mfa_secret_key,
+    )
+
+```
+
 # Accessing Data
 
 As of writing this README, the following methods are supported:

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -18,7 +18,7 @@ SESSION_FILE = ".mm/mm_session.pickle"
 
 
 class MonarchMoneyEndpoints(object):
-    BASE_URL = "https://api.monarchmoney.com/"
+    BASE_URL = "https://api.monarchmoney.com"
 
     @classmethod
     def getLoginEndpoint(cls) -> str:

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -14,7 +14,8 @@ from graphql import DocumentNode
 AUTH_HEADER_KEY = "authorization"
 CSRF_KEY = "csrftoken"
 ERRORS_KEY = "error_code"
-SESSION_FILE = ".mm/mm_session.pickle"
+SESSION_DIR = ".mm"
+SESSION_FILE = f"{SESSION_DIR}/mm_session.pickle"
 
 
 class MonarchMoneyEndpoints(object):
@@ -657,6 +658,9 @@ class MonarchMoney(object):
         Saves the auth token needed to access a Monarch Money account.
         """
         session_data = {"token": self._token}
+        if not os.path.exists(SESSION_DIR):
+            os.makedirs(SESSION_DIR)
+
         with open(filename, "wb") as fh:
             pickle.dump(session_data, fh)
 

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -40,7 +40,10 @@ class LoginFailedException(Exception):
 
 class MonarchMoney(object):
     def __init__(
-        self, session_file: str = SESSION_FILE, timeout: int = 10, token: Optional[str] = None
+        self,
+        session_file: str = SESSION_FILE,
+        timeout: int = 10,
+        token: Optional[str] = None,
     ) -> None:
         self._headers = {
             "Client-Platform": "web",

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -61,6 +61,13 @@ class MonarchMoney(object):
         """Sets the default timeout on GraphQL API calls, in seconds."""
         self._timeout = timeout_secs
 
+    @property
+    def token(self) -> str:
+        return self._token
+
+    def set_token(self, token: str) -> None:
+        self._token = token
+
     async def interactive_login(
         self, use_saved_session: bool = True, save_session: bool = True
     ) -> None:
@@ -670,7 +677,7 @@ class MonarchMoney(object):
         """
         with open(filename, "rb") as fh:
             data = pickle.load(fh)
-            self._token = data["token"]
+            self.set_token(data["token"])
             self._headers["Authorization"] = f"Token {self._token}"
 
     async def _login_user(self, email: str, password: str) -> None:
@@ -696,7 +703,7 @@ class MonarchMoney(object):
                     )
 
                 response = await resp.json()
-                self._token = response["token"]
+                self.set_token(response["token"])
                 self._headers["Authorization"] = f"Token {self._token}"
 
     async def _multi_factor_authenticate(
@@ -727,7 +734,7 @@ class MonarchMoney(object):
                     raise LoginFailedException(error_message)
 
                 response = await resp.json()
-                self._token = response["token"]
+                self.set_token(response["token"])
                 self._headers["Authorization"] = f"Token {self._token}"
 
     def _get_graphql_client(self) -> Client:

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -40,7 +40,7 @@ class LoginFailedException(Exception):
 
 class MonarchMoney(object):
     def __init__(
-        self, session_file: str = SESSION_FILE, timeout: int = 10, token: str = None
+        self, session_file: str = SESSION_FILE, timeout: int = 10, token: Optional[str] = None
     ) -> None:
         self._headers = {
             "Client-Platform": "web",

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-install_requires = [
-    "aiohttp>=3.8.4",
-    "gql>=3.4",
-]
+install_requires = ["aiohttp>=3.8.4", "gql>=3.4", "oathtool>=2.3.1"]
 
 setup(
     name="monarchmoney",


### PR DESCRIPTION
This PR may be a bit more opinionated so feel free to ignore. For my use case, I'd like to be able to provide an auth token as a string rather than using the pickled session file. Personally, I think the developer should pickle the session file outside of this project. But to maintain that compatibility while allowing for using an auth token string, this PR does the following:

-  Sets the auth token in the headers while instantiating. This allows the client to authorize without needing to call login() (assuming the token is valid).
-  Remove cookies variables. The auth token is the only requirement to authorize the client.
-  Fixes the issue when saving the session file if the session directory does not exist by checking and creating the session directory.

I appreciate any feedback. Thanks!