### PR TITLE
Add functionality to update individual transactions

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -656,7 +656,7 @@ class MonarchMoney(object):
             category_id="160185840107743863",
             merchant_id="Amazon",
             goal_id="160826408575920275",
-            amount=123.45,            
+            amount=123.45,
             date="2023-11-09",
             hide_from_reports=False,
             needs_review=False,
@@ -724,7 +724,7 @@ class MonarchMoney(object):
                 "id": transaction_id,
             }
         }
-        
+
         # Using 'is not None' to allow writing of empty strings
         if category_id is not None:
             variables["input"].update({"category": category_id})

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -636,12 +636,11 @@ class MonarchMoney(object):
         )
 
     async def update_transaction(
-		self,
-		transaction_id: int,
-      	**kwargs
+        self,
+        transaction_id: int,
+        **kwargs
     ) -> Dict[str, Any]:
-        a=1    
-    	"""
+        """
         Updates a single existing transaction as identified by the transaction_id
         Key/Values in kwargs are appended to variables in gql_call
         """

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -635,6 +635,83 @@ class MonarchMoney(object):
             operation="Web_GetCashFlowPage", variables=variables, graphql_query=query
         )
 
+    async def update_transaction(
+		self,
+		transaction_id: int,
+      	**kwargs
+    ) -> Dict[str, Any]:
+        a=1    
+    	"""
+        Updates a single existing transaction as identified by the transaction_id
+        Key/Values in kwargs are appended to variables in gql_call
+        """
+        query = gql("""
+        mutation Web_TransactionDrawerUpdateTransaction($input: UpdateTransactionMutationInput!) {
+            updateTransaction(input: $input) {
+            transaction {
+                id
+                amount
+                pending
+                date
+                hideFromReports
+                needsReview
+                reviewedAt
+                reviewedByUser {
+                id
+                name
+                __typename
+                }
+                plaidName
+                notes
+                isRecurring
+                category {
+                id
+                __typename
+                }
+                goal {
+                id
+                __typename
+                }
+                merchant {
+                id
+                name
+                __typename
+                }
+                __typename
+            }
+            errors {
+                ...PayloadErrorFields
+                __typename
+            }
+            __typename
+            }
+        }
+
+        fragment PayloadErrorFields on PayloadError {
+            fieldErrors {
+            field
+            messages
+            __typename
+            }
+            message
+            code
+            __typename
+        }
+        """)
+        
+        variables = {
+        "input": {
+            "id": transaction_id,        
+        }
+        }
+        variables['input'].update(kwargs)    
+
+        return await self.gql_call(
+            operation="Web_TransactionDrawerUpdateTransaction",
+            variables=variables,
+            graphql_query=query
+        )
+        
     async def gql_call(
         self,
         operation: str,

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -654,7 +654,7 @@ class MonarchMoney(object):
         mm.update_transaction(
             transaction_id="160820461792094418",
             category_id="160185840107743863",
-            merchant_id="Amazon",
+            merchant_name="Amazon",
             goal_id="160826408575920275",
             amount=123.45,
             date="2023-11-09",
@@ -725,23 +725,25 @@ class MonarchMoney(object):
             }
         }
 
-        # Using 'is not None' to allow writing of empty strings
-        if category_id is not None:
-            variables["input"].update({"category": category_id})
-        if merchant_name is not None:
-            variables["input"].update({"name": merchant_name})
-        if goal_id is not None:
-            variables["input"].update({"goalId": goal_id})
-        if date is not None:
-            variables["input"].update({"date": date})
-        if amount is not None:
+        # Special handling as these items can never be null
+        if amount:
             variables["input"].update({"amount": amount})
+        if date:
+            variables["input"].update({"date": date})
+
+        # Handling of Booleans parameters
+        # 'None' should not change the value in the transaction therefore it should not be included in the variables dict        
         if hide_from_reports is not None:
-            variables["input"].update({"hideFromReports": hide_from_reports})
+            # Casting the passed value as bool.  Therefore, empty strings cast to False and any other value casts to True.
+            variables["input"].update({"hideFromReports": bool(hide_from_reports)})
         if needs_review is not None:
-            variables["input"].update({"needsReview": needs_review})
-        if notes is not None:
-            variables["input"].update({"notes": notes})
+            variables["input"].update({"needsReview": bool(needs_review)})
+
+        # Remaining items
+        variables["input"].update({"category": category_id})
+        variables["input"].update({"name": merchant_name})
+        variables["input"].update({"goalId": goal_id})
+        variables["input"].update({"notes": notes})
 
         return await self.gql_call(
             operation="Web_TransactionDrawerUpdateTransaction",

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -637,14 +637,23 @@ class MonarchMoney(object):
 
     async def update_transaction(
         self,
-        transaction_id: int,
-        **kwargs
+        transaction_id: str,
+        category_id: Optional[str] = None,
+        merchant_id: Optional[str] = None,
+        goal_id: Optional[str] = None,
+        amount: Optional[float] = None,
+        date: Optional[str] = None,
+        hide_from_reports: Optional[bool] = None,
+        needs_review: Optional[bool] = None,
+        notes: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Updates a single existing transaction as identified by the transaction_id
-        Key/Values in kwargs are appended to variables in gql_call
+        Explicitly defining parameters that worked in testing.
+        date in "%Y-%m-%d" or 2023-10-30
         """
-        query = gql("""
+        query = gql(
+            """
         mutation Web_TransactionDrawerUpdateTransaction($input: UpdateTransactionMutationInput!) {
             updateTransaction(input: $input) {
             transaction {
@@ -696,21 +705,37 @@ class MonarchMoney(object):
             code
             __typename
         }
-        """)
-        
+        """
+        )
+
         variables = {
-        "input": {
-            "id": transaction_id,        
+            "input": {
+                "id": transaction_id,
+            }
         }
-        }
-        variables['input'].update(kwargs)    
+        if category_id:
+            variables["input"].update({"category": category_id})
+        if merchant_id:
+            variables["input"].update({"merchant": merchant_id})
+        if goal_id:
+            variables["input"].update({"goalId": goal_id})
+        if date:
+            variables["input"].update({"date": date})
+        if amount:
+            variables["input"].update({"amount": amount})
+        if hide_from_reports is not None:
+            variables["input"].update({"hideFromReports": hide_from_reports})
+        if needs_review is not None:
+            variables["input"].update({"needsReview": needs_review})
+        if notes:
+            variables["input"].update({"notes": notes})
 
         return await self.gql_call(
             operation="Web_TransactionDrawerUpdateTransaction",
             variables=variables,
-            graphql_query=query
+            graphql_query=query,
         )
-        
+
     async def gql_call(
         self,
         operation: str,

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -725,24 +725,24 @@ class MonarchMoney(object):
             }
         }
 
-         # Special handling as these items can never be null
+        # Special handling as these items can never be null
         if amount:
             variables["input"].update({"amount": amount})
         if date:
             variables["input"].update({"date": date})
 
         # Handling of Booleans parameters
-        # 'None' should not change the value in the transaction therefore it should not be included in the variables dict        
+        # 'None' should not change the value in the transaction therefore it should not be included in the variables dict
         if hide_from_reports is not None:
             # Casting the passed value as bool.  Therefore, empty strings cast to False and any other value casts to True.
             variables["input"].update({"hideFromReports": bool(hide_from_reports)})
         if needs_review is not None:
             variables["input"].update({"needsReview": bool(needs_review)})
-        
+
         # Ensure that notes is explicitly included to avoid errant erasing of existing notes
         if notes is not None:
             variables["input"].update({"notes": notes})
-        
+
         # Remaining items
         variables["input"].update({"category": category_id})
         variables["input"].update({"name": merchant_name})

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -725,7 +725,7 @@ class MonarchMoney(object):
             }
         }
 
-        # Special handling as these items can never be null
+         # Special handling as these items can never be null
         if amount:
             variables["input"].update({"amount": amount})
         if date:
@@ -738,12 +738,15 @@ class MonarchMoney(object):
             variables["input"].update({"hideFromReports": bool(hide_from_reports)})
         if needs_review is not None:
             variables["input"].update({"needsReview": bool(needs_review)})
-
+        
+        # Ensure that notes is explicitly included to avoid errant erasing of existing notes
+        if notes is not None:
+            variables["input"].update({"notes": notes})
+        
         # Remaining items
         variables["input"].update({"category": category_id})
         variables["input"].update({"name": merchant_name})
         variables["input"].update({"goalId": goal_id})
-        variables["input"].update({"notes": notes})
 
         return await self.gql_call(
             operation="Web_TransactionDrawerUpdateTransaction",

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -724,21 +724,23 @@ class MonarchMoney(object):
                 "id": transaction_id,
             }
         }
-        if category_id:
+        
+        # Using 'is not None' to allow writing of empty strings
+        if category_id is not None:
             variables["input"].update({"category": category_id})
-        if merchant_name:
+        if merchant_name is not None:
             variables["input"].update({"name": merchant_name})
-        if goal_id:
+        if goal_id is not None:
             variables["input"].update({"goalId": goal_id})
-        if date:
+        if date is not None:
             variables["input"].update({"date": date})
-        if amount:
+        if amount is not None:
             variables["input"].update({"amount": amount})
         if hide_from_reports is not None:
             variables["input"].update({"hideFromReports": hide_from_reports})
         if needs_review is not None:
             variables["input"].update({"needsReview": needs_review})
-        if notes:
+        if notes is not None:
             variables["input"].update({"notes": notes})
 
         return await self.gql_call(

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -639,7 +639,7 @@ class MonarchMoney(object):
         self,
         transaction_id: str,
         category_id: Optional[str] = None,
-        merchant_id: Optional[str] = None,
+        merchant_name: Optional[str] = None,
         goal_id: Optional[str] = None,
         amount: Optional[float] = None,
         date: Optional[str] = None,
@@ -651,6 +651,17 @@ class MonarchMoney(object):
         Updates a single existing transaction as identified by the transaction_id
         Explicitly defining parameters that worked in testing.
         date in "%Y-%m-%d" or 2023-10-30
+        mm.update_transaction(
+            transaction_id="160820461792094418",
+            category_id="160185840107743863",
+            merchant_id="Amazon",
+            goal_id="160826408575920275",
+            amount=123.45,            
+            date="2023-11-09",
+            hide_from_reports=False,
+            needs_review=False,
+            notes=f'Updated On: {datetime.now().strftime("%m/%d/%Y %H:%M:%S")}',
+        )
         """
         query = gql(
             """
@@ -715,8 +726,8 @@ class MonarchMoney(object):
         }
         if category_id:
             variables["input"].update({"category": category_id})
-        if merchant_id:
-            variables["input"].update({"merchant": merchant_id})
+        if merchant_name:
+            variables["input"].update({"name": merchant_name})
         if goal_id:
             variables["input"].update({"goalId": goal_id})
         if date:


### PR DESCRIPTION
This request adds a new definition in monarchmoney.py which enables updating of a single transaction.  I tested all parameters from the web calls to see which are writeable by the user.  These writable parameters are what are in the definition call.  Testing was done on both a manually created transaction and one source from a live account.

I was surprised to see that the merchant value was updated by using the "name" of the merchant (e.g. Amazon) as opposed to the id.  It is quite possible that someone with better gql skills could move this to use the merchantId for cleaner implementation.

Sample call:
```
mm.update_transaction(
            transaction_id="160820461792094418",
            category_id="160185840107743863",
            merchant_name="Amazon",
            goal_id="160826408575920275",
            amount=123.45,            
            date="2023-11-09",
            hide_from_reports=False,
            needs_review=False,
            notes=f'Updated On: {datetime.now().strftime("%m/%d/%Y %H:%M:%S")}',
        )
```
Finally, I am new to making PRs, so please let me know if there are basic things that I have missed.