### PR TITLE
Remove twine and wheel dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install aiohttp gql[all] oathtool setuptools twine wheel
+        pip install aiohttp gql[all] oathtool setuptools
     - name: Build package
       run: | 
         python setup.py check


### PR DESCRIPTION
Remove `twine` and `wheel` from release action, since they aren't likely needed with the use of the pypi action