### PR TITLE
Add workflow to run pyre on PRs and merges into main

### DIFF
--- a/.github/workflows/pyre.yml
+++ b/.github/workflows/pyre.yml
@@ -1,0 +1,36 @@
+# Pyre is a performant type checker for Python compliant with
+# PEP 484. Pyre can analyze codebases with millions of lines
+# of code incrementally – providing instantaneous feedback
+# to developers as they write code.
+#
+# See https://pyre-check.org
+
+name: Pyre
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+    contents: read
+
+jobs:
+  pyre:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Run Pyre
+        uses: facebook/pyre-action@60697a7858f7cc8470d8cc494a3cf2ad6b06560d
+        with:
+          repo-directory: './'
+          requirements-path: 'requirements.txt'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,7 @@
 # This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Publish Python Package to PyPI
+name: Publish to PyPI
 
 on:
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib
 .DS_Store
 .mm
 .monarchmoney.egg-info
+.venv
 .vscode
 *.pyc
 __pycache__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+aiohttp>=3.8.4
+gql>=3.4
+oathtool>=2.3.1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-install_requires = ["aiohttp>=3.8.4", "gql>=3.4", "oathtool>=2.3.1"]
+install_requires = open("requirements.txt", "r").read().split("\n")
 
 setup(
     name="monarchmoney",


### PR DESCRIPTION
- Migrate dependency management to use `requirements.txt`
  - Update `.gitignore` to ignore `.venv` dir
  - Adds `pyre.yml` to run Pyre against all merges and PRs on main
  - Rename the PyPI publishing action