### PR TITLE
Fixes bool filters, add new bool filters, and add createdAt and updatedAt to get_transactions

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -310,6 +310,8 @@ class MonarchMoney(object):
         hidden_from_reports: Optional[bool] = None,
         is_split: Optional[bool] = None,
         is_recurring: Optional[bool] = None,
+        imported_from_mint: Optional[bool] = None,
+        synced_from_institution: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         Gets transaction data from the account.
@@ -327,6 +329,8 @@ class MonarchMoney(object):
         :param hidden_from_reports: a bool to filter for whether the transactions are hidden from reports.
         :param is_split: a bool to filter for whether the transactions are split.
         :param is_recurring: a bool to filter for whether the transactions are recurring.
+        :param imported_from_mint: a bool to filter for whether the transactions were imported from mint.
+        :param synced_from_institution: a bool to filter for whether the transactions were synced from an institution.
         """
 
         query = gql(
@@ -421,6 +425,12 @@ class MonarchMoney(object):
 
         if is_split is not None:
             variables["filters"]["isSplit"] = is_split
+
+        if imported_from_mint is not None:
+            variables["filters"]["importedFromMint"] = is_split
+
+        if synced_from_institution is not None:
+            variables["filters"]["syncedFromInstitution"] = synced_from_institution
 
         if start_date and end_date:
             variables["filters"]["startDate"] = start_date

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -305,11 +305,11 @@ class MonarchMoney(object):
         category_ids: List[str] = [],
         account_ids: List[str] = [],
         tag_ids: List[str] = [],
-        has_attachments: bool = False,
-        has_notes: bool = False,
-        hidden_from_reports: bool = False,
-        is_split: bool = False,
-        is_recurring: bool = False,
+        has_attachments: Optional[bool] = None,
+        has_notes: Optional[bool] = None,
+        hidden_from_reports: Optional[bool] = None,
+        is_split: Optional[bool] = None,
+        is_recurring: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         Gets transaction data from the account.
@@ -406,19 +406,20 @@ class MonarchMoney(object):
             },
         }
 
-        if has_attachments:
+        # If bool filters are not defined (i.e. None), then it should not apply the filter
+        if has_attachments is not None:
             variables["filters"]["hasAttachments"] = has_attachments
 
-        if has_notes:
+        if has_notes is not None:
             variables["filters"]["hasNotes"] = has_notes
 
-        if hidden_from_reports:
+        if hidden_from_reports is not None:
             variables["filters"]["hideFromReports"] = hidden_from_reports
 
-        if is_recurring:
+        if is_recurring is not None:
             variables["filters"]["isRecurring"] = is_recurring
 
-        if is_split:
+        if is_split is not None:
             variables["filters"]["isSplit"] = is_split
 
         if start_date and end_date:

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -357,12 +357,13 @@ class MonarchMoney(object):
             notes
             isRecurring
             reviewStatus
-            needsReview
             attachments {
               id
               __typename
             }
             isSplitTransaction
+            createdAt
+            updatedAt
             category {
               id
               name
@@ -401,13 +402,23 @@ class MonarchMoney(object):
                 "categories": category_ids,
                 "accounts": account_ids,
                 "tags": tag_ids,
-                "hasAttachments": has_attachments,
-                "hasNotes": has_notes,
-                "hideFromReports": hidden_from_reports,
-                "isRecurring": is_recurring,
-                "isSplit": is_split,
             },
         }
+
+        if has_attachments:
+            variables["filters"]["hasAttachments"] = has_attachments
+
+        if has_notes:
+            variables["filters"]["hasNotes"] = has_notes
+
+        if hidden_from_reports:
+            variables["filters"]["hideFromReports"] = hidden_from_reports
+
+        if is_recurring:
+            variables["filters"]["isRecurring"] = is_recurring
+
+        if is_split:
+            variables["filters"]["isSplit"] = is_split
 
         if start_date and end_date:
             variables["filters"]["startDate"] = start_date

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -427,7 +427,7 @@ class MonarchMoney(object):
             variables["filters"]["isSplit"] = is_split
 
         if imported_from_mint is not None:
-            variables["filters"]["importedFromMint"] = is_split
+            variables["filters"]["importedFromMint"] = imported_from_mint
 
         if synced_from_institution is not None:
             variables["filters"]["syncedFromInstitution"] = synced_from_institution

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -357,6 +357,7 @@ class MonarchMoney(object):
             notes
             isRecurring
             reviewStatus
+            needsReview
             attachments {
               id
               __typename


### PR DESCRIPTION
This PR does the following:

#### Fixes Bool Filter Default Behavior

- Resolves an issue with bool filters where the default behavior, when not explicitly provided, incorrectly defaulted to `False`, resulting in unintended filter application. The fix ensures that if bool filters are not provided, the filter is not applied.

#### Introduces Two New Bool Filters

- Adds two new bool filters, `imported_from_mint` and `synced_from_institution`, providing more detail in filtering transactions based on their import source.

#### Transaction Response Enhancements

- Includes `createdAt` and `updatedAt` fields in the transaction response.

Please let me know if there's anything I should change or any feedback. Thanks!
