### PR TITLE
Change default limits to 100 to match docs

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -297,7 +297,7 @@ class MonarchMoney(object):
 
     async def get_transactions(
         self,
-        limit: int = 1000,
+        limit: int = 100,
         offset: Optional[int] = 0,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
@@ -314,7 +314,7 @@ class MonarchMoney(object):
         """
         Gets transaction data from the account.
 
-        :param limit: the maximum number of transactions to download, defaults to 1000.
+        :param limit: the maximum number of transactions to download, defaults to 100.
         :param offset: the number of transactions to skip (offset) before retrieving results.
         :param start_date: the earliest date to get transactions from, in "yyyy-mm-dd" format.
         :param end_date: the latest date to get transactions from, in "yyyy-mm-dd" format.
@@ -539,7 +539,7 @@ class MonarchMoney(object):
 
     async def get_cashflow(
         self,
-        limit: int = 1000,
+        limit: int = 100,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
     ) -> Dict[str, Any]:
@@ -652,7 +652,7 @@ class MonarchMoney(object):
 
     async def get_cashflow_summary(
         self,
-        limit: int = 1000,
+        limit: int = 100,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
     ) -> Dict[str, Any]:

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -17,6 +17,7 @@ CSRF_KEY = "csrftoken"
 ERRORS_KEY = "error_code"
 SESSION_DIR = ".mm"
 SESSION_FILE = f"{SESSION_DIR}/mm_session.pickle"
+DEFAULT_RECORD_LIMIT = 100
 
 
 class MonarchMoneyEndpoints(object):
@@ -297,7 +298,7 @@ class MonarchMoney(object):
 
     async def get_transactions(
         self,
-        limit: int = 100,
+        limit: int = DEFAULT_RECORD_LIMIT,
         offset: Optional[int] = 0,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
@@ -314,7 +315,7 @@ class MonarchMoney(object):
         """
         Gets transaction data from the account.
 
-        :param limit: the maximum number of transactions to download, defaults to 100.
+        :param limit: the maximum number of transactions to download, defaults to DEFAULT_RECORD_LIMIT.
         :param offset: the number of transactions to skip (offset) before retrieving results.
         :param start_date: the earliest date to get transactions from, in "yyyy-mm-dd" format.
         :param end_date: the latest date to get transactions from, in "yyyy-mm-dd" format.
@@ -539,7 +540,7 @@ class MonarchMoney(object):
 
     async def get_cashflow(
         self,
-        limit: int = 100,
+        limit: int = DEFAULT_RECORD_LIMIT,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
     ) -> Dict[str, Any]:
@@ -652,7 +653,7 @@ class MonarchMoney(object):
 
     async def get_cashflow_summary(
         self,
-        limit: int = 100,
+        limit: int = DEFAULT_RECORD_LIMIT,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
     ) -> Dict[str, Any]:

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -14,10 +14,10 @@ from graphql import DocumentNode
 
 AUTH_HEADER_KEY = "authorization"
 CSRF_KEY = "csrftoken"
+DEFAULT_RECORD_LIMIT = 100
 ERRORS_KEY = "error_code"
 SESSION_DIR = ".mm"
 SESSION_FILE = f"{SESSION_DIR}/mm_session.pickle"
-DEFAULT_RECORD_LIMIT = 100
 
 
 class MonarchMoneyEndpoints(object):


### PR DESCRIPTION
The docs say the default return is 100, whereas the code is 1000. I think having a smaller number as a default makes more sense, as the defaults will primarily be used by new users figuring out the library.