### PR TITLE
Don't include the boolean filter flags unless specified by the caller

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -305,11 +305,11 @@ class MonarchMoney(object):
         category_ids: List[str] = [],
         account_ids: List[str] = [],
         tag_ids: List[str] = [],
-        has_attachments: bool = False,
-        has_notes: bool = False,
-        hidden_from_reports: bool = False,
-        is_split: bool = False,
-        is_recurring: bool = False,
+        has_attachments: bool = None,
+        has_notes: bool = None,
+        hidden_from_reports: bool = None,
+        is_split: bool = None,
+        is_recurring: bool = None,
     ) -> Dict[str, Any]:
         """
         Gets transaction data from the account.
@@ -401,13 +401,19 @@ class MonarchMoney(object):
                 "categories": category_ids,
                 "accounts": account_ids,
                 "tags": tag_ids,
-                "hasAttachments": has_attachments,
-                "hasNotes": has_notes,
-                "hideFromReports": hidden_from_reports,
-                "isRecurring": is_recurring,
-                "isSplit": is_split,
             },
         }
+
+        if has_attachments is not None:
+            variables["filters"]["hasAttachments"] = has_attachments
+        if has_notes is not None:
+            variables["filters"]["hasNotes"] = has_notes
+        if hidden_from_reports is not None:
+            variables["filters"]["hideFromReports"] = hidden_from_reports
+        if is_recurring is not None:
+            variables["filters"]["isRecurring"] = is_recurring
+        if is_split is not None:
+            variables["filters"]["isSplit"] = is_split
 
         if start_date and end_date:
             variables["filters"]["startDate"] = start_date


### PR DESCRIPTION
Fixes #46 

Currently, we default 5 parameters in the `get_transactions` method to False, and always add them as variables in the call to MonarchMoney.

https://github.com/hammem/monarchmoney/blob/6c66ee78bec2f963054600813d79ec1a8824c296/monarchmoney/monarchmoney.py#L298-L313

https://github.com/hammem/monarchmoney/blob/6c66ee78bec2f963054600813d79ec1a8824c296/monarchmoney/monarchmoney.py#L395-L410

This results in the default, no-arguments call to `get_transactions` returning only transactions that meet _all_ of these requirements:

1. Mustn't have attachments
2. Mustn't have notes
3. Are not hidden
4. Are not split
5. Are not recurring

Which doesn't seem like the correct default behavior (and isn't the default behavior of the website transaction search).

---

By default, the `get_transactions` call, with no arguments, should return _all_ transactions.

This changes the code to default these boolean filters to `None` instead, and exclude them from the variables unless explicitly specified by the caller.