### PR TITLE
Add get_transaction_category_groups and include additional fields to existing methods

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -511,6 +511,29 @@ class MonarchMoney(object):
         )
         return await self.gql_call(operation="GetCategories", graphql_query=query)
 
+    async def get_transaction_category_groups(self) -> Dict[str, Any]:
+        """
+        Gets all the category groups configured in the account.
+        """
+        query = gql(
+            """
+          query ManageGetCategoryGroups {
+              categoryGroups {
+                  id
+                  name
+                  order
+                  type
+                  updatedAt
+                  createdAt
+                  __typename
+              }
+          }
+        """
+        )
+        return await self.gql_call(
+            operation="ManageGetCategoryGroups", graphql_query=query
+        )
+
     async def get_transaction_tags(self) -> Dict[str, Any]:
         """
         Gets all the tags configured in the account.

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -482,6 +482,11 @@ class MonarchMoney(object):
             needsReview
             attachments {
               id
+              extension
+              filename
+              originalAssetUrl
+              publicId
+              sizeBytes
               __typename
             }
             isSplitTransaction

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -499,6 +499,8 @@ class MonarchMoney(object):
             systemCategory
             isSystemCategory
             isDisabled
+            updatedAt
+            createdAt
             group {
               id
               name


### PR DESCRIPTION
This PR does the following:

#### Introduces a new method for getting the Category Groups
- This new methods retrieves all the category groups that exist within the user's account

#### Include some additional fields to existing
- get_transactions now includes more detailed attachment fields
- get_transaction_categories now includes createdAt and updatedAt

Please let me know if there's anything I should change or any feedback. Thanks!