### PR TITLE
Implement delete_transaction API call

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -624,6 +624,55 @@ class MonarchMoney(object):
             variables=variables,
         )
 
+    async def delete_transaction(self, transaction_id: str) -> bool:
+        """
+        Deletes the given transaction.
+
+        :param transaction_id: the ID of the transaction targeted for deletion.
+        """
+        query = gql(
+            """
+          mutation Common_DeleteTransactionMutation($input: DeleteTransactionMutationInput!) {
+            deleteTransaction(input: $input) {
+              deleted
+              errors {
+                ...PayloadErrorFields
+                __typename
+              }
+              __typename
+            }
+          }
+  
+          fragment PayloadErrorFields on PayloadError {
+            fieldErrors {
+              field
+              messages
+              __typename
+            }
+            message
+            code
+            __typename
+          }
+        """
+        )
+
+        variables = {
+            "input": {
+                "transactionId": transaction_id,
+            },
+        }
+
+        response = await self.gql_call(
+            operation="Common_DeleteTransactionMutation",
+            graphql_query=query,
+            variables=variables,
+        )
+
+        if not response["deleteTransaction"]["deleted"]:
+            raise RequestFailedException(response["deleteTransaction"]["errors"])
+
+        return True
+
     async def get_transaction_categories(self) -> Dict[str, Any]:
         """
         Gets all the categories configured in the account.


### PR DESCRIPTION
Resolves #24 

Tested, and behavior is as expected.

<details>
<summary>Test Results</summary>

```
In [3]: result = asyncio.run(mm.create_transaction(
   ...:         "2023-12-02",
   ...:         "160542457753312071",
   ...:         -15,
   ...:         "My Test Merchant 3",
   ...:         "160539862437534145",
   ...:         notes = "Using API!"
   ...:         ))

In [4]: result
Out[4]:
{'createTransaction': {'errors': None,
  'transaction': {'id': '163101432494496747'},
  '__typename': 'CreateTransactionMutation'}}

In [5]: delete_result = asyncio.run(mm.delete_transaction("163101432494496747"))

In [6]: delete_result
Out[6]: True
```

Saw on the website as the transaction was created and then deleted.

</details>