### PR TITLE
Adds delete_transaction_categories() and delete_transaction_category()

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ As of writing this README, the following methods are supported:
 
 ## Mutating Methods
 
+- `delete_transaction_category` - deletes a category for transactions
 - `request_accounts_refresh` - requests a syncronization / refresh of all accounts linked to Monarch Money. This is a **non-blocking call**. If the user wants to check on the status afterwards, they must call `is_accounts_refresh_complete`.
-- `request_accounts_refresh_and_waid` - requests a syncronization / refresh of all accounts linked to Monarch Money. This is a **blocking call** and will not return until the refresh is complete or no longer running.
+- `request_accounts_refresh_and_wait` - requests a syncronization / refresh of all accounts linked to Monarch Money. This is a **blocking call** and will not return until the refresh is complete or no longer running.
 - `create_transaction` - creates a transaction with the given attributes
 - `update_transaction` - modifes one or more attributes for an existing transaction
 - `update_transaction_splits` - modifes how a transaction is split (or not)


### PR DESCRIPTION
Adds methods to enable deleting of one or more categories.  Was able to test out a few different scenarios to ensure it's working as expected.

**Example categories at start**
![Example categories at start](https://github.com/hammem/monarchmoney/assets/1057714/ac8ddfec-c87c-4d78-b383-a5e5a2e98db7)

**Results of API calls in testing**
![Results of API calls in testing](https://github.com/hammem/monarchmoney/assets/1057714/7ecf7495-381e-4a05-8eb5-a715f18f8f09)

Deletion of a non-existent category results in an exception, as expected.

*Note: It appears 're-deleting' returns success from the API, but that may just be a timing / sync issue.*  

**Categories after single and multi-delete operations**
![Categories after deletion](https://github.com/hammem/monarchmoney/assets/1057714/44790496-950e-4279-ad65-54fb58127fc9)

After tests, the `Hotels`, `Airlines`, and `Entertainment` categories are all gone.
