### PR TITLE
Add transaction summary method

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ As of writing this README, the following methods are supported:
 - `get_account_holdings` - gets all of the securities in a brokerage or similar type of account
 - `get_budgets` — all the budgets and the corresponding actual amounts
 - `get_subscription_details` - gets the Monarch Money account's status (e.g. paid or trial)
+- `get_transactions_summary` - gets the transaction summary data from the transactions page
 - `get_transactions` - gets transaction data, defaults to returning the last 100 transactions; can also be searched by date range
 - `get_transaction_categories` - gets all of the categories configured in the account
 - `get_transaction_details` - gets detailed transaction data for a single transaction

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ def main() -> None:
     # Use session file
     mm = MonarchMoney(session_file=_SESSION_FILE_)
     asyncio.run(mm.interactive_login())
-    
+
     # Subscription details
     subs = asyncio.run(mm.get_subscription_details())
     print(subs)

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ def main() -> None:
     # Use session file
     mm = MonarchMoney(session_file=_SESSION_FILE_)
     asyncio.run(mm.interactive_login())
-
+    
     # Subscription details
     subs = asyncio.run(mm.get_subscription_details())
     print(subs)
@@ -25,6 +25,11 @@ def main() -> None:
     budgets = asyncio.run(mm.get_budgets())
     with open("budgets.json", "w") as outfile:
         json.dump(budgets, outfile)
+
+    # Transactions summary
+    transactions_summary = asyncio.run(mm.get_transactions_summary())
+    with open("transactions_summary.json", "w") as outfile:
+        json.dump(transactions_summary, outfile)
 
     # # Transaction categories
     categories = asyncio.run(mm.get_transaction_categories())

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -650,9 +650,9 @@ class MonarchMoney(object):
             graphql_query=query,
         )
 
-    async def get_transaction_page_summary(self) -> Dict[str, Any]:
+    async def get_transactions_summary(self) -> Dict[str, Any]:
         """
-        Gets transaction page summary from the account.
+        Gets transactions summary from the account.
         """
 
         query = gql(

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -650,6 +650,42 @@ class MonarchMoney(object):
             graphql_query=query,
         )
 
+    async def get_transaction_page_summary(self) -> Dict[str, Any]:
+        """
+        Gets transaction page summary from the account.
+        """
+
+        query = gql(
+            """
+            query GetTransactionsPage($filters: TransactionFilterInput) {
+              aggregates(filters: $filters) {
+                summary {
+                  ...TransactionsSummaryFields
+                  __typename
+                }
+                __typename
+              }
+            }
+
+            fragment TransactionsSummaryFields on TransactionsSummary {
+              avg
+              count
+              max
+              maxExpense
+              sum
+              sumIncome
+              sumExpense
+              first
+              last
+              __typename
+            }
+        """
+        )
+        return await self.gql_call(
+            operation="GetTransactionsPage",
+            graphql_query=query,
+        )
+
     async def get_transactions(
         self,
         limit: int = DEFAULT_RECORD_LIMIT,


### PR DESCRIPTION
Adds transaction summary method. 

This method will be helpful in introducing another feature to allow getting all transactions. The transaction summary includes the total number of transactions in a Monarch account, which can be used to create a loop through transactions where the maximum number of iterations is determined by the total number of transactions in the account, also accounting for timeouts and limits.