### PR TITLE
Add ability to upload account history csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ As of writing this README, the following methods are supported:
 - `update_transaction_splits` - modifies how a transaction is split (or not)
 - `set_budget_amount` - sets a budget's value to the given amount (date allowed, will only apply to month specified by default). A zero amount value will "unset" or "clear" the budget for the given category.
 - `create_manual_account` - creates a new manual account
+- `upload_account_balance_history` - uploads account history csv file for a given account
 
 # Contributing
 

--- a/monarchmoney/__init__.py
+++ b/monarchmoney/__init__.py
@@ -9,6 +9,7 @@ from .monarchmoney import (
     MonarchMoneyEndpoints,
     MonarchMoney,
     RequireMFAException,
+    RequestFailedException,
 )
 
 __version__ = "0.1.8"

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -35,7 +35,7 @@ class MonarchMoneyEndpoints(object):
         return cls.BASE_URL + "/graphql"
 
     @classmethod
-    def getAccountBalanceHistoryUploadEndpoint(cls):
+    def getAccountBalanceHistoryUploadEndpoint(cls) -> str:
         return cls.BASE_URL + "/account-balance-history/upload/"
 
 

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1875,8 +1875,8 @@ class MonarchMoney(object):
         """
         Uploads the account balance history csv for a given account.
 
-        :param account_id: The account ID to upload the balance history.
-        :param csv_content: CSV representation of the account history.
+        :param account_id: The account ID to apply the history to.
+        :param csv_content: CSV representation of the balance history.
         """
         if not account_id or not csv_content:
             raise RequestFailedException("account_id and csv_content cannot be empty")

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1,10 +1,10 @@
 import calendar
 from datetime import datetime
+import json
 import os
 import pickle
 import oathtool
 import time
-import json
 from typing import Any, Dict, Optional, List
 
 from aiohttp import ClientSession, FormData
@@ -1870,15 +1870,18 @@ class MonarchMoney(object):
         )
 
     async def upload_account_balance_history(
-        self, account_id: str, csv_content: str, filename: str = "upload.csv"
+        self, account_id: str, csv_content: str
     ) -> None:
         """
-        Uploads the account balance history csv for the given account.
+        Uploads the account balance history csv for a given account.
 
         :param account_id: The account ID to upload the balance history.
         :param csv_content: CSV representation of the account history.
-        :param filename: Optional filename to use for uploading the balance history.
         """
+        if not account_id or not csv_content:
+            raise RequestFailedException("account_id and csv_content cannot be empty")
+
+        filename = "upload.csv"
         form = FormData()
         form.add_field("files", csv_content, filename=filename, content_type="text/csv")
         form.add_field("account_files_mapping", json.dumps({filename: account_id}))

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1869,7 +1869,9 @@ class MonarchMoney(object):
             graphql_query=query,
         )
 
-    async def upload_account_balance_history(self, account_id: str, csv_content: str, filename: str = 'upload.csv') -> None:
+    async def upload_account_balance_history(
+        self, account_id: str, csv_content: str, filename: str = "upload.csv"
+    ) -> None:
         """
         Uploads the account balance history csv for the given account.
 
@@ -1878,15 +1880,16 @@ class MonarchMoney(object):
         :param filename: Optional filename to use for uploading the balance history.
         """
         form = FormData()
-        form.add_field('files', csv_content, filename=filename, content_type='text/csv')
-        form.add_field('account_files_mapping', json.dumps({filename: account_id}))
+        form.add_field("files", csv_content, filename=filename, content_type="text/csv")
+        form.add_field("account_files_mapping", json.dumps({filename: account_id}))
 
         async with ClientSession(headers=self._headers) as session:
-            resp = await session.post(MonarchMoneyEndpoints.getAccountBalanceHistoryUploadEndpoint(), data=form)
+            resp = await session.post(
+                MonarchMoneyEndpoints.getAccountBalanceHistoryUploadEndpoint(),
+                data=form,
+            )
             if resp.status != 200:
-                raise RequestFailedException(
-                    f"HTTP Code {resp.status}: {resp.reason}"
-                )
+                raise RequestFailedException(f"HTTP Code {resp.status}: {resp.reason}")
 
     async def gql_call(
         self,


### PR DESCRIPTION
The PR adds the ability to upload an account history CSV file to a give account.

This functionality is useful for me to automate updating the balance of an account that isn't supported by Monarch.

Thanks for making and maintaining this library!