### PR TITLE
Feature: account history

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ As of writing this README, the following methods are supported:
 - `get_accounts` - gets all the accounts linked to Monarch Money
 - `get_account_holdings` - gets all of the securities in a brokerage or similar type of account
 - `get_account_type_options` - all account types and their subtypes available in Monarch Money- 
+- `get_account_history` - gets all daily account history for the specified account
 - `get_institutions` -- gets institutions linked to Monarch Money
 - `get_budgets` — all the budgets and the corresponding actual amounts
 - `get_subscription_details` - gets the Monarch Money account's status (e.g. paid or trial)

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -711,9 +711,16 @@ class MonarchMoney(object):
             variables=variables,
         )
 
-        balance_history = account_details["snapshots"]
+        # Parse JSON
+        account_name = account_details["account"]["displayName"]
+        account_balance_history = account_details["snapshots"]
 
-        return balance_history
+        # Append account identification data to account balance history
+        for i in account_balance_history:
+            i.update(dict(accountId=str(account_id)))
+            i.update(dict(accountName=account_name))
+
+        return account_balance_history
 
     async def get_institutions(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
Added support for pulling historical account balances.

The new method pulls account details and extracts the `snapshots` node. It also loops through each entry in the node and adds `accountId` and `accountName` for extra descriptors.

Users may choose to loop through all of their accounts (this is what I plan to do). It might make sense in the future to update this method or add a new method to do the all-account loop automatically, rather than each user creating their own loop through which to gather historical balance data for all of their accounts.

Example of data returned:

```
[{'date': '2024-01-09',
  'signedBalance': 2.33,
  '__typename': 'AccountSnapshot',
  'accountId': 'xxxACCOUNT_IDxxx',
  'accountName': 'xxxACCOUNT_NAMExxx'},
 {'date': '2024-01-10',
  'signedBalance': 2.33,
  '__typename': 'AccountSnapshot',
  'accountId': 'xxxACCOUNT_IDxxx',
  'accountName': 'xxxACCOUNT_NAMExxx'}]
```