### PR TITLE
Enable loading of a default session file

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,32 @@ await mm.login(
 
 ```
 
+# Use a Saved Session
+
+You can easily save your session for use later on.  While we don't know precisely how long a session lasts, authors of this library have found it can last several months.
+
+```python
+from monarchmoney import MonarchMoney, RequireMFAException
+
+mm = MonarchMoney()
+mm.interactive_login()
+
+# Save it for later, no more need to login!
+mm.save_session()
+```
+
+Once you've logged in, you can simply load the saved session to pick up where you left off.
+
+```python
+from monarchmoney import MonarchMoney, RequireMFAException
+
+mm = MonarchMoney()
+mm.load_session()
+
+# Then, start accessing data!
+await mm.get_accounts()
+```
+
 # Accessing Data
 
 As of writing this README, the following methods are supported:

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -2238,7 +2238,7 @@ class MonarchMoney(object):
         with open(filename, "wb") as fh:
             pickle.dump(session_data, fh)
 
-    def load_session(self, filename: str) -> None:
+    def load_session(self, filename: str = SESSION_FILE) -> None:
         """
         Loads pre-existing auth token from a Python pickle file.
         """


### PR DESCRIPTION
Updates the `load_session()` method to make it easier to use.  Also updates the README, so it's clear to others how to use the library and avoid perpetually logging in.