### PR TITLE
feat: add create_transaction_category

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ As of writing this README, the following methods are supported:
 
 - `delete_transaction_category` - deletes a category for transactions
 - `delete_transaction_categories` - deletes a list of transaction categories for transactions
+- `create_transaction_category` - creates a category for transactions
 - `request_accounts_refresh` - requests a synchronization / refresh of all accounts linked to Monarch Money. This is a **non-blocking call**. If the user wants to check on the status afterwards, they must call `is_accounts_refresh_complete`.
 - `request_accounts_refresh_and_wait` - requests a synchronization / refresh of all accounts linked to Monarch Money. This is a **blocking call** and will not return until the refresh is complete or no longer running.
 - `create_transaction` - creates a transaction with the given attributes

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1481,7 +1481,7 @@ class MonarchMoney(object):
         group_id: str,
         transaction_category_name: str,
         rollover_start_month: datetime = datetime.today().replace(day=1),
-        icon: str = "\U00002753	",
+        icon: str = "\U00002753",
         rollover_enabled: bool = False,
         rollover_type: str = "monthly",
     ):

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1481,7 +1481,7 @@ class MonarchMoney(object):
         group_id: str,
         transaction_category_name: str,
         rollover_start_month: datetime = datetime.today().replace(day=1),
-        icon: str = "❓",
+        icon: str = "\U00002753	",
         rollover_enabled: bool = False,
         rollover_type: str = "monthly",
     ):
@@ -1489,7 +1489,7 @@ class MonarchMoney(object):
         Creates a new transaction category
         :param group_id: The transaction category group id
         :param transaction_category_name: The name of the transaction category being created
-        :param icon: The icon of the transaction category
+        :param icon: The icon of the transaction category. This accepts the unicode string or emoji.
         :param rollover_start_month: The datetime of the rollover start month
         :param rollover_enabled: A bool whether the transaction category should be rolled over or not
         :param rollover_type: The budget roll over type

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1243,6 +1243,94 @@ class MonarchMoney(object):
             operation="ManageGetCategoryGroups", graphql_query=query
         )
 
+    async def create_transaction_category(
+        self,
+        group_id: str,
+        transaction_category_name: str,
+        rollover_start_month: datetime = datetime.today().replace(day=1),
+        icon: str = "❓",
+        rollover_enabled: bool = False,
+        rollover_type: str = "monthly",
+    ):
+        """
+        Creates a new transaction category
+        :param group_id: The transaction category group id
+        :param transaction_category_name: The name of the transaction category being created
+        :param icon: The icon of the transaction category
+        :param rollover_start_month: The datetime of the rollover start month
+        :param rollover_enabled: A bool whether the transaction category should be rolled over or not
+        :param rollover_type: The budget roll over type
+        """
+
+        query = gql(
+            """
+            mutation Web_CreateCategory($input: CreateCategoryInput!) {
+                createCategory(input: $input) {
+                    errors {
+                        ...PayloadErrorFields
+                        __typename
+                    }
+                    category {
+                        id
+                        ...CategoryFormFields
+                        __typename
+                    }
+                    __typename
+                }
+            }
+            fragment PayloadErrorFields on PayloadError {
+                fieldErrors {
+                    field
+                    messages
+                    __typename
+                }
+                message
+                code
+                __typename
+            }
+            fragment CategoryFormFields on Category {
+                id
+                order
+                name
+                icon
+                systemCategory
+                systemCategoryDisplayName
+                budgetVariability
+                isSystemCategory
+                isDisabled
+                group {
+                    id
+                    type
+                    groupLevelBudgetingEnabled
+                    __typename
+                }
+                rolloverPeriod {
+                    id
+                    startMonth
+                    startingBalance
+                    __typename
+                }
+                __typename
+            }
+            """
+        )
+        variables = {
+            "input": {
+                "group": group_id,
+                "name": transaction_category_name,
+                "icon": icon,
+                "rolloverEnabled": rollover_enabled,
+                "rolloverType": rollover_type,
+                "rolloverStartMonth": rollover_start_month.strftime("%Y-%m-%d"),
+            },
+        }
+
+        return await self.gql_call(
+            operation="Web_CreateCategory",
+            graphql_query=query,
+            variables=variables,
+        )
+
     async def get_transaction_tags(self) -> Dict[str, Any]:
         """
         Gets all the tags configured in the account.

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -303,7 +303,7 @@ class MonarchMoney(object):
         }
 
         return await self.gql_call(
-            operation="Web_CreateManualAccount",
+            operation="Common_CreateTransactionMutation",
             graphql_query=query,
             variables=variables,
         )

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -303,7 +303,7 @@ class MonarchMoney(object):
         }
 
         return await self.gql_call(
-            operation="Common_CreateTransactionMutation",
+            operation="Web_CreateManualAccount",
             graphql_query=query,
             variables=variables,
         )


### PR DESCRIPTION
This PR does the following adds a new method `create_transaction_category` which creates new transaction categories

Notes:
- Set default parameters for `create_transaction_category` based on the UI defaults
- When entering non-emoji strings (i.e. "test"), a new transaction category would be created with the icon string "test")

Appreciate any feedback. Thanks!