### PR TITLE
adds set_transaction_tags method

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ As of writing this README, the following methods are supported:
 - `update_transaction` - modifies one or more attributes for an existing transaction
 - `delete_transaction` - deletes a given transaction by the provided transaction id
 - `update_transaction_splits` - modifies how a transaction is split (or not)
+- `set_transaction_tags` - sets the tags on a transaction
 - `set_budget_amount` - sets a budget's value to the given amount (date allowed, will only apply to month specified by default). A zero amount value will "unset" or "clear" the budget for the given category.
 - `create_manual_account` - creates a new manual account
 - `upload_account_balance_history` - uploads account history csv file for a given account

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1593,7 +1593,7 @@ class MonarchMoney(object):
         self,
         transaction_id: str,
         tag_ids: List[str],
-    ):
+    ) -> Dict[str, Any]:
         """
         Sets the tags on a transaction
         :param transaction_id: The transaction id

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1,19 +1,18 @@
+import asyncio
 import calendar
-from datetime import datetime
 import json
 import os
 import pickle
-import oathtool
 import time
-from typing import Any, Dict, Optional, List
+from datetime import datetime
+from typing import Any, Dict, List, Optional
 
+import oathtool
 from aiohttp import ClientSession, FormData
 from aiohttp.client import DEFAULT_TIMEOUT
-import asyncio
-from gql import gql, Client
+from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
 from graphql import DocumentNode
-
 
 AUTH_HEADER_KEY = "authorization"
 CSRF_KEY = "csrftoken"
@@ -1588,6 +1587,61 @@ class MonarchMoney(object):
         )
         return await self.gql_call(
             operation="GetHouseholdTransactionTags", graphql_query=query
+        )
+
+    async def set_transaction_tags(
+        self,
+        transaction_id: str,
+        tag_ids: List[str],
+    ):
+        """
+        Sets the tags on a transaction
+        :param transaction_id: The transaction id
+        :param tag_ids: The list of tag ids to set on the transaction.
+          Overwrites existing tags. Empty list removes all tags.
+        """
+
+        query = gql(
+            """
+          mutation Web_SetTransactionTags($input: SetTransactionTagsInput!) {
+            setTransactionTags(input: $input) {
+              errors {
+                ...PayloadErrorFields
+                __typename
+              }
+              transaction {
+                id
+                tags {
+                  id
+                  __typename
+                }
+                __typename
+              }
+              __typename
+            }
+          }
+
+          fragment PayloadErrorFields on PayloadError {
+            fieldErrors {
+              field
+              messages
+              __typename
+            }
+            message
+            code
+            __typename
+          }
+          """
+        )
+
+        variables = {
+            "input": {"transactionId": transaction_id, "tagIds": tag_ids},
+        }
+
+        return await self.gql_call(
+            operation="Web_SetTransactionTags",
+            graphql_query=query,
+            variables=variables,
         )
 
     async def get_transaction_details(


### PR DESCRIPTION
Adds a method for setting tags on the transaction.

Please feel free to advise on the imports changes. That's how my IDE really wanted them to be formatted. Not sure if it was black or isort or what.

I think this resolves #26.