### PR TITLE
Use explicitly set session_file in save/load_session

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -2496,6 +2496,9 @@ class MonarchMoney(object):
         """
         Loads pre-existing auth token from a Python pickle file.
         """
+        if filename is None:
+            filename = self._session_file
+
         with open(filename, "rb") as fh:
             data = pickle.load(fh)
             self.set_token(data["token"])

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -2492,7 +2492,7 @@ class MonarchMoney(object):
         with open(filename, "wb") as fh:
             pickle.dump(session_data, fh)
 
-    def load_session(self, filename: str = SESSION_FILE) -> None:
+    def load_session(self, filename: str = None) -> None:
         """
         Loads pre-existing auth token from a Python pickle file.
         """

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -2487,6 +2487,7 @@ class MonarchMoney(object):
         """
         if filename is None:
             filename = self._session_file
+        filename = os.path.abspath(filename)
 
         session_data = {"token": self._token}
 

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -2481,13 +2481,15 @@ class MonarchMoney(object):
             document=graphql_query, operation_name=operation, variable_values=variables
         )
 
-    def save_session(self, filename: str) -> None:
+    def save_session(self, filename: str = None) -> None:
         """
         Saves the auth token needed to access a Monarch Money account.
         """
+        if filename is None:
+            filename = self._session_file
+
         session_data = {"token": self._token}
-        if not os.path.exists(SESSION_DIR):
-            os.makedirs(SESSION_DIR)
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
 
         with open(filename, "wb") as fh:
             pickle.dump(session_data, fh)

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -2489,8 +2489,8 @@ class MonarchMoney(object):
             filename = self._session_file
 
         session_data = {"token": self._token}
-        os.makedirs(os.path.dirname(filename), exist_ok=True)
 
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
         with open(filename, "wb") as fh:
             pickle.dump(session_data, fh)
 

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -2481,7 +2481,7 @@ class MonarchMoney(object):
             document=graphql_query, operation_name=operation, variable_values=variables
         )
 
-    def save_session(self, filename: str = None) -> None:
+    def save_session(self, filename: Optional[str] = None) -> None:
         """
         Saves the auth token needed to access a Monarch Money account.
         """
@@ -2495,7 +2495,7 @@ class MonarchMoney(object):
         with open(filename, "wb") as fh:
             pickle.dump(session_data, fh)
 
-    def load_session(self, filename: str = None) -> None:
+    def load_session(self, filename: Optional[str] = None) -> None:
         """
         Loads pre-existing auth token from a Python pickle file.
         """


### PR DESCRIPTION
Previously, `load_session()` would always attempt to load the session file from `./.mm/mm_session.pickle`, even if the `MonarchMoney` object was given a different `session_file` value (e.g., something in `~/.local/state`). Additionally, `save_session()` would always require an explicitly passed `session_file`.

This PR changes that to instead try to load from and save to `self._session_file`. If `session_file` was not explicitly set, then it will still default to the previous behavior.