### PR TITLE
Add queries for net value, recent daily account values

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -247,7 +247,7 @@ class MonarchMoney(object):
             graphql_query=query,
         )
 
-    async def get_accounts_page_recent_balance(self, start_date: date = None) -> Dict[str, Any]:
+    async def get_recent_account_balances(self, start_date: date = None) -> Dict[str, Any]:
         """
         Retrieves the daily balance for all accounts starting from `start_date`. If
         `start_date` is None, then the last 31 days are requested.

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -271,8 +271,14 @@ class MonarchMoney(object):
         )
 
     async def get_account_snapshots_by_type(self, start_date: date, timeframe: str):
-        # if timeframe not in ('year', 'month', 'day'):
-        #     raise Exception(f'Unknown timeframe "{timeframe}"')
+        """
+        Retrieves snapshots of the net values of all accounts of a given type, with either a yearly
+        monthly granularity.
+        Note, `month` is not a full ISO datestring, as it doesn't include the day.
+        Instead it looks like, e.g., 2023-01
+        """
+        if timeframe not in ('year', 'month'):
+            raise Exception(f'Unknown timeframe "{timeframe}"')
 
         query = gql("""
             query GetSnapshotsByAccountType($startDate: Date!, $timeframe: Timeframe!) {
@@ -298,7 +304,13 @@ class MonarchMoney(object):
             }
         )
 
-    async def get_aggregate_snapshots(self, start_date: date = None, end_date: date = None, account_type: str = None) -> dict:
+    async def get_aggregate_snapshots(
+            self, start_date: Optional[date] = None, end_date: Optional[date] = None, account_type: Optional[str] = None
+    ) -> dict:
+        """
+        Retrieves the daily net value of all accounts, optionally between `start_date` and `end_date`,
+        and optionally only for accounts of type `account_type`.
+        """
         query = gql("""
             query GetAggregateSnapshots($filters: AggregateSnapshotFilters) {
                 aggregateSnapshots(filters: $filters) {
@@ -313,7 +325,7 @@ class MonarchMoney(object):
             start_date = start_date.isoformat()
         else:
             # The mobile app defaults to 150 years ago today
-            # The mobile app might have a leap year bug, so I'm just setting day=1
+            # The mobile app might have a leap year bug, so instead default to setting day=1
             today = date.today()
             start_date = date(year=today.year - 150, month=today.month, day=1).isoformat()
         if end_date is not None:

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -247,7 +247,9 @@ class MonarchMoney(object):
             graphql_query=query,
         )
 
-    async def get_recent_account_balances(self, start_date: date = None) -> Dict[str, Any]:
+    async def get_recent_account_balances(
+        self, start_date: date = None
+    ) -> Dict[str, Any]:
         """
         Retrieves the daily balance for all accounts starting from `start_date`. If
         `start_date` is None, then the last 31 days are requested.
@@ -255,7 +257,8 @@ class MonarchMoney(object):
         if start_date is None:
             start_date = date.today() - timedelta(days=31)
 
-        query = gql("""
+        query = gql(
+            """
             query GetAccountRecentBalances($startDate: Date!) {
                 accounts {
                     id
@@ -263,11 +266,12 @@ class MonarchMoney(object):
                     __typename
                 }
             }
-        """)
+        """
+        )
         return await self.gql_call(
-            operation='GetAccountRecentBalances',
+            operation="GetAccountRecentBalances",
             graphql_query=query,
-            variables={'startDate': start_date.isoformat()}
+            variables={"startDate": start_date.isoformat()},
         )
 
     async def get_account_snapshots_by_type(self, start_date: date, timeframe: str):
@@ -277,10 +281,11 @@ class MonarchMoney(object):
         Note, `month` is not a full ISO datestring, as it doesn't include the day.
         Instead it looks like, e.g., 2023-01
         """
-        if timeframe not in ('year', 'month'):
+        if timeframe not in ("year", "month"):
             raise Exception(f'Unknown timeframe "{timeframe}"')
 
-        query = gql("""
+        query = gql(
+            """
             query GetSnapshotsByAccountType($startDate: Date!, $timeframe: Timeframe!) {
                 snapshotsByAccountType(startDate: $startDate, timeframe: $timeframe) {
                     accountType
@@ -294,24 +299,26 @@ class MonarchMoney(object):
                     __typename
                 }
             }
-        """)
+        """
+        )
         return await self.gql_call(
-            operation='GetSnapshotsByAccountType',
+            operation="GetSnapshotsByAccountType",
             graphql_query=query,
-            variables={
-                'startDate': start_date.isoformat(),
-                'timeframe': timeframe
-            }
+            variables={"startDate": start_date.isoformat(), "timeframe": timeframe},
         )
 
     async def get_aggregate_snapshots(
-            self, start_date: Optional[date] = None, end_date: Optional[date] = None, account_type: Optional[str] = None
+        self,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+        account_type: Optional[str] = None,
     ) -> dict:
         """
         Retrieves the daily net value of all accounts, optionally between `start_date` and `end_date`,
         and optionally only for accounts of type `account_type`.
         """
-        query = gql("""
+        query = gql(
+            """
             query GetAggregateSnapshots($filters: AggregateSnapshotFilters) {
                 aggregateSnapshots(filters: $filters) {
                     date
@@ -319,7 +326,8 @@ class MonarchMoney(object):
                     __typename
                 }
             }
-        """)
+        """
+        )
 
         if start_date is not None:
             start_date = start_date.isoformat()
@@ -327,20 +335,22 @@ class MonarchMoney(object):
             # The mobile app defaults to 150 years ago today
             # The mobile app might have a leap year bug, so instead default to setting day=1
             today = date.today()
-            start_date = date(year=today.year - 150, month=today.month, day=1).isoformat()
+            start_date = date(
+                year=today.year - 150, month=today.month, day=1
+            ).isoformat()
         if end_date is not None:
             end_date = end_date.isoformat()
 
         return await self.gql_call(
-            operation='GetAggregateSnapshots',
+            operation="GetAggregateSnapshots",
             graphql_query=query,
             variables={
-                'filters': {
-                    'startDate': start_date,
-                    'endDate': end_date,
-                    'accountType': account_type
+                "filters": {
+                    "startDate": start_date,
+                    "endDate": end_date,
+                    "accountType": account_type,
                 }
-            }
+            },
         )
 
     async def create_manual_account(

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -248,7 +248,7 @@ class MonarchMoney(object):
         )
 
     async def get_recent_account_balances(
-        self, start_date: date = None
+        self, start_date: Optional[date] = None
     ) -> Dict[str, Any]:
         """
         Retrieves the daily balance for all accounts starting from `start_date`. If

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -4,7 +4,7 @@ import json
 import os
 import pickle
 import time
-from datetime import datetime
+from datetime import datetime, date, timedelta
 from typing import Any, Dict, List, Optional, Union
 
 import oathtool
@@ -245,6 +245,29 @@ class MonarchMoney(object):
         return await self.gql_call(
             operation="GetAccountTypeOptions",
             graphql_query=query,
+        )
+
+    async def get_accounts_page_recent_balance(self, start_date: date = None) -> Dict[str, Any]:
+        """
+        Retrieves the daily balance for all accounts starting from `start_date`. If
+        `start_date` is None, then the last 31 days are requested.
+        """
+        if start_date is None:
+            start_date = date.today() - timedelta(days=31)
+
+        query = gql("""
+            query GetAccountRecentBalances($startDate: Date!) {
+                accounts {
+                    id
+                    recentBalances(startDate: $startDate)
+                    __typename
+                }
+            }
+        """)
+        return await self.gql_call(
+            operation='GetAccountRecentBalances',
+            graphql_query=query,
+            variables={'startDate': start_date.isoformat()}
         )
 
     async def create_manual_account(


### PR DESCRIPTION
This PR adds 3 queries, for retrieving `aggregateSnapshots`, `snapshotsByAccountType`, and `accounts.recentBalances`.

`recentBalances` is used by the web app to retrieve the daily value of a given account, primarily to generate the sparklines seen on the Accounts page.

`snapshotsByAccountType` is used by the web app to generate the bar charts showing different account types' contributions to your net worth, on the Accounts page.

`aggregateSnapshots` is used by the mobile app to show your historical daily net worth, or to see the historical value of certain account types, e.g. cash, loans, brokerage, etc..