### PR TITLE
Use `getpass` to retrieve user password

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1,5 +1,6 @@
 import asyncio
 import calendar
+import getpass
 import json
 import os
 import pickle
@@ -88,7 +89,7 @@ class MonarchMoney(object):
     ) -> None:
         """Performs an interactive login for iPython and similar environments."""
         email = input("Email: ")
-        passwd = input("Password: ")
+        passwd = getpass.getpass("Password: ")
         try:
             await self.login(email, passwd, use_saved_session, save_session)
         except RequireMFAException:


### PR DESCRIPTION
This PR changes `interactive_login()` to instead use [`getpass`](https://docs.python.org/3/library/getpass.html) to retrieve the user's password. This ensures that user passwords don't get printed to the terminal, or prints a warning that password input will be visible if it detects a terminal that can't hide input.