### PR TITLE
Remove base64 encoded logo image fields from GQL queries

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -170,7 +170,6 @@ class MonarchMoney(object):
             holdingsCount
             manualInvestmentsTrackingMethod
             order
-            icon
             logoUrl
             type {
               name
@@ -192,7 +191,6 @@ class MonarchMoney(object):
                 plaidInstitutionId
                 name
                 status
-                logo
                 __typename
               }
               __typename
@@ -200,7 +198,6 @@ class MonarchMoney(object):
             institution {
               id
               name
-              logo
               primaryColor
               url
               __typename
@@ -613,7 +610,6 @@ class MonarchMoney(object):
               holdingsCount
               manualInvestmentsTrackingMethod
               order
-              icon
               logoUrl
               type {
                 name
@@ -636,7 +632,6 @@ class MonarchMoney(object):
                   plaidInstitutionId
                   name
                   status
-                  logo
                   __typename
                 }
                 __typename
@@ -644,7 +639,6 @@ class MonarchMoney(object):
               institution {
                 id
                 name
-                logo
                 primaryColor
                 url
                 __typename
@@ -717,7 +711,6 @@ class MonarchMoney(object):
               category {
                 id
                 name
-                icon
                 group {
                   id
                   type
@@ -805,7 +798,6 @@ class MonarchMoney(object):
               institution {
                 id
                 name
-                logo
                 url
                 __typename
               }
@@ -834,7 +826,6 @@ class MonarchMoney(object):
               updateRequired
               institution {
                 hasIssuesReported
-                logo
                 status
                 balanceStatus
                 transactionsStatus
@@ -978,7 +969,6 @@ class MonarchMoney(object):
               categories {
                 id
                 name
-                icon
                 order
                 budgetVariability
                 rolloverPeriod {
@@ -995,7 +985,6 @@ class MonarchMoney(object):
             goals @include(if: $useLegacyGoals) {
               id
               name
-              icon
               completedAt
               targetDate
               __typename
@@ -1227,7 +1216,6 @@ class MonarchMoney(object):
             category {
               id
               name
-              icon
               __typename
             }
             merchant {
@@ -1424,7 +1412,6 @@ class MonarchMoney(object):
             id
             order
             name
-            icon
             systemCategory
             isSystemCategory
             isDisabled
@@ -1565,7 +1552,6 @@ class MonarchMoney(object):
                 id
                 order
                 name
-                icon
                 systemCategory
                 systemCategoryDisplayName
                 budgetVariability
@@ -1832,7 +1818,6 @@ class MonarchMoney(object):
             }
             category {
               id
-              icon
               name
               __typename
             }
@@ -1854,7 +1839,6 @@ class MonarchMoney(object):
           fragment TransactionDrawerAccountSectionFields on Account {
             id
             displayName
-            icon
             logoUrl
             id
             mask
@@ -1891,7 +1875,6 @@ class MonarchMoney(object):
               category {
                 id
                 name
-                icon
                 __typename
               }
               merchant {
@@ -1908,7 +1891,6 @@ class MonarchMoney(object):
                 }
                 category {
                   id
-                  icon
                   name
                   __typename
                 }
@@ -1963,7 +1945,6 @@ class MonarchMoney(object):
                   }
                   category {
                     id
-                    icon
                     name
                     __typename
                   }
@@ -2020,7 +2001,6 @@ class MonarchMoney(object):
                 category {
                   id
                   name
-                  icon
                   group {
                     id
                     type
@@ -2456,13 +2436,11 @@ class MonarchMoney(object):
                 category {
                   id
                   name
-                  icon
                   __typename
                 }
                 account {
                   id
                   displayName
-                  icon
                   logoUrl
                   __typename
                 }


### PR DESCRIPTION
From #89, removes the `icon` and `logo` fields from the GQL queries, to reduce data weight.  `logoURL` fields remain, for use cases where a logo is needed.