### PR TITLE
Account Refresh Bugfix

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -686,13 +686,13 @@ class MonarchMoney(object):
         if account_ids:
             return all(
                 [
-                    not x["hasSyncInProgress"]
+                    x["hasSyncInProgress"]
                     for x in response["accounts"]
                     if x["id"] in account_ids
                 ]
             )
         else:
-            return all([not x["hasSyncInProgress"] for x in response["accounts"]])
+            return all([x["hasSyncInProgress"] for x in response["accounts"]])
 
     async def request_accounts_refresh_and_wait(
         self,


### PR DESCRIPTION
Fixed bug where method `is_accounts_refresh_complete` returned the wrong value. The method previously return true if every account did not have its' sync in progress. I removed the `not` from before the return statement so that now it returns true if all accounts have started their sync. I am relatively certain that this is what the code should do, please close this branch if not.