### PR TITLE
Add "Projects Using this Library" to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,4 +158,6 @@ Don't forget to use a password unique to your Monarch account and to enable mult
 
 # Projects Using This Library
 
+*Disclaimer: These projects are neither affiliated nor endorsed by the `monarchmoney` project.*
+
 - [monarch-money-amazon-connector](https://github.com/elsell/monarch-money-amazon-connector): Automate annotating and tagging Amazon transactions (ALPHA)

--- a/README.md
+++ b/README.md
@@ -155,3 +155,7 @@ Actions are configured in this repo to run against all PRs and merges which will
 If you currently use Google or 'Continue with Google' to access your Monarch account, you'll need to set a password to leverage this API.  You can set a password on your Monarch account by going to your [security settings](https://app.monarchmoney.com/settings/security).  
 
 Don't forget to use a password unique to your Monarch account and to enable multi-factor authentication!
+
+# Projects Using This Library
+
+- [monarch-money-amazon-connector](https://github.com/elsell/monarch-money-amazon-connector): Automate annotating and tagging Amazon transactions (ALPHA)


### PR DESCRIPTION
## Summary

_Closes #122_

- Add "Projects Using This Library" section to the README.
- Add my project ([monarch-money-amazon-connector](https://github.com/elsell/monarch-money-amazon-connector)) to the list.

## Rationale

The `monarchmoney` package has the potential to enable a variety of neat and useful community integrations with Monarch Money. Since `monarchmoney` is the key enabler of such applications, I think it makes sense to include a list of projects that use the package to facilitate discovery of community projects.

## Caution

Of course, each entry on this list should be approved by the `monarchmoney` maintainers. I've added a disclaimer to the README, but if the maintainers think the wording should be stronger, I have no opposition.