### PR TITLE
Fix http 403 errors

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -59,7 +59,10 @@ class MonarchMoney(object):
         token: Optional[str] = None,
     ) -> None:
         self._headers = {
+            "Accept": "application/json",
             "Client-Platform": "web",
+            "Content-Type": "application/json",
+            "User-Agent": "MonarchMoneyAPI (https://github.com/hammem/monarchmoney)",
         }
         if token:
             self._headers["Authorization"] = f"Token {token}"
@@ -2852,14 +2855,18 @@ class MonarchMoney(object):
                 MonarchMoneyEndpoints.getLoginEndpoint(), json=data
             ) as resp:
                 if resp.status != 200:
-                    response = await resp.json()
-                    error_message = (
-                        response["error_code"]
-                        if response is not None
-                        else "Unknown error"
-                    )
-                    raise LoginFailedException(error_message)
-
+                    try:
+                        response = await resp.json()
+                        error_message = (
+                            response["error_code"]
+                            if response is not None
+                            else "Unknown error"
+                        )
+                        raise LoginFailedException(error_message)
+                    except:
+                        raise LoginFailedException(
+                            f"HTTP Code {resp.status}: {resp.reason}\nRaw response: {resp.text}"
+                        )
                 response = await resp.json()
                 self.set_token(response["token"])
                 self._headers["Authorization"] = f"Token {self._token}"


### PR DESCRIPTION
Monarch appears to have made some changes around headers it requires when making API calls.

Added the required ones, as well as an new exception handling logic to make future debugging easier.