### PR TITLE
feat: add get_transactions_summary_card method

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ As of writing this README, the following methods are supported:
 - `get_subscription_details` - gets the Monarch Money account's status (e.g. paid or trial)
 - `get_recurring_transactions` - gets the future recurring transactions, including merchant and account details
 - `get_transactions_summary` - gets the transaction summary data from the transactions page
+- `get_transactions_summary_card` - gets the transaction summary card data from the transactions page
 - `get_transactions` - gets transaction data, defaults to returning the last 100 transactions; can also be searched by date range
 - `get_transaction_categories` - gets all of the categories configured in the account
 - `get_transaction_category_groups` all category groups configured in the account- 

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1433,6 +1433,32 @@ class MonarchMoney(object):
             graphql_query=query,
         )
 
+    async def get_transactions_summary_card(self) -> Dict[str, Any]:
+        """
+        Gets transactions summary from the account using the transaction summary card operation.
+        """
+
+        query = gql(
+            """
+            query Web_GetTransactionsSummaryCard($filters: TransactionFilterInput!) {
+              allTransactions(filters: $filters) {
+                totalCount
+                __typename
+              }
+            }
+            """
+        )
+
+        variables = {
+            "filters": {"search": "", "categories": [], "accounts": [], "tags": []}
+        }
+
+        return await self.gql_call(
+            operation="Web_GetTransactionsSummaryCard",
+            graphql_query=query,
+            variables=variables,
+        )
+
     async def get_transactions(
         self,
         limit: int = DEFAULT_RECORD_LIMIT,


### PR DESCRIPTION
# Issue
The Monarch UI shows more transactions in the summary card than is returned from the `get_transactions_summary` function. In the example below, `get_transactions_summary` returns 39,974 transactions while 41,995 transactions are displayed as the "Total transactions" in Monarch.

![image](https://github.com/user-attachments/assets/fd431509-89bd-4753-8d18-e712ae8af05d)

`get_transactions_summary` = 

```json
{
  "aggregates": [
    {
      "summary": {
        "avg": 14.635267423825487,
        "count": 39974,
        "max": 000,
        "maxExpense":  000,
        "sum": 000,
        "sumIncome": 000,
        "sumExpense": 000,
        "first": "2011-09-29",
        "last": "2025-02-22",
        "__typename": "TransactionsSummary"
      },
      "__typename": "AggregateData"
    }
  ]
}
```

# Changes
1. Added a function to call the `Web_GetTransactionsSummaryCard` operation in the Monarch API.
2. Updated readme.

# Tests
1. New method returns data as expected.
2. Unit tests passed.

```json
{
  "allTransactions": {
    "totalCount": 41995,
    "__typename": "TransactionList"
  }
}
```

