### PR TITLE
Change URL to new domain

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -24,7 +24,7 @@ SESSION_FILE = f"{SESSION_DIR}/mm_session.pickle"
 
 
 class MonarchMoneyEndpoints(object):
-    BASE_URL = "https://api.monarchmoney.com"
+    BASE_URL = "https://api.monarch.com"
 
     @classmethod
     def getLoginEndpoint(cls) -> str:


### PR DESCRIPTION
At Monarch we recently changed our domain from monarchmoney.com to monarch.com. You can read a bit more in the announcement blog post [here](https://www.monarch.com/blog/migration-to-monarch). 