### PR TITLE
Fix session persistence by sending trusted_device and handling null tokenExpiration

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -2844,7 +2844,7 @@ class MonarchMoney(object):
         data = {
             "password": password,
             "supports_mfa": True,
-            "trusted_device": False,
+            "trusted_device": True,
             "username": email,
         }
 
@@ -2863,6 +2863,13 @@ class MonarchMoney(object):
                     )
 
                 response = await resp.json()
+                tokexp = response.get("tokenExpiration")
+
+                if tokexp not in (None, "null"):
+                    raise LoginFailedException(
+                        f"Short-lived token returned (tokenExpiration={tokexp})."
+                    )
+
                 self.set_token(response["token"])
                 self._headers["Authorization"] = f"Token {self._token}"
 
@@ -2876,7 +2883,7 @@ class MonarchMoney(object):
             "password": password,
             "supports_mfa": True,
             "totp": code,
-            "trusted_device": False,
+            "trusted_device": True,
             "username": email,
         }
 
@@ -2900,6 +2907,13 @@ class MonarchMoney(object):
                             f"HTTP Code {resp.status}: {resp.reason}\nRaw response: {resp.text}"
                         )
                 response = await resp.json()
+                tokexp = response.get("tokenExpiration")
+
+                if tokexp not in (None, "null"):
+                    raise LoginFailedException(
+                        f"Short-lived token returned (tokenExpiration={tokexp})."
+                    )
+
                 self.set_token(response["token"])
                 self._headers["Authorization"] = f"Token {self._token}"
 


### PR DESCRIPTION
The community has run into an issue where sessions were never persisting because Monarch only gives a long-lived token when `trusted_device=True` is sent. Without that flag, the API returns a short-lived token with a real expiration, so the saved session couldn’t be reused.

This update makes two small changes:
- Sends `trusted_device=True` on both the initial login and the MFA login
- Verifies that `tokenExpiration` is null before saving the session

Once these two things are in place, the session file stays valid and the integration no longer asks for login every run.

This is a minimal change, nothing else is touched. Just fixes the actual problem with persistent sessions.
