### PR TITLE
Fix missing request argument after gql 4.0 upgrade (closes issue #172)

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -12,6 +12,7 @@ import oathtool
 from aiohttp import ClientSession, FormData
 from aiohttp.client import DEFAULT_TIMEOUT
 from gql import Client, gql
+from gql.graphql_request import GraphQLRequest
 from gql.transport.aiohttp import AIOHTTPTransport
 from graphql import DocumentNode
 
@@ -2795,9 +2796,10 @@ class MonarchMoney(object):
         """
         Makes a GraphQL call to Monarch Money's API.
         """
-        return await self._get_graphql_client().execute_async(
-            request=graphql_query, variable_values=variables, operation_name=operation
+        request = GraphQLRequest(
+            graphql_query, variable_values=variables, operation_name=operation
         )
+        return await self._get_graphql_client().execute_async(request)
 
     def save_session(self, filename: Optional[str] = None) -> None:
         """

--- a/tests/test_monarchmoney.py
+++ b/tests/test_monarchmoney.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import json
 from gql import Client
+from gql.graphql_request import GraphQLRequest
 from monarchmoney import MonarchMoney
 from monarchmoney.monarchmoney import LoginFailedException
 
@@ -110,9 +111,12 @@ class TestMonarchMoney(unittest.IsolatedAsyncioTestCase):
 
         mock_execute_async.assert_called_once()
 
-        kwargs = mock_execute_async.call_args.kwargs
-        self.assertEqual(kwargs["operation_name"], "Common_DeleteAccount")
-        self.assertEqual(kwargs["variable_values"], {"id": "170123456789012345"})
+        args = mock_execute_async.call_args.args
+        request = args[0]
+        self.assertEqual(len(args), 1, "execute_async should receive one positional argument (GraphQLRequest)")
+        self.assertIsInstance(request, GraphQLRequest)
+        self.assertEqual(request.operation_name, "Common_DeleteAccount")
+        self.assertEqual(request.variable_values, {"id": "170123456789012345"})
 
         self.assertIsNotNone(result, "Expected result to not be None")
         self.assertEqual(result["deleteAccount"]["deleted"], True)


### PR DESCRIPTION
Replicated reported issue, fixed it, and updated unit tests to pass with fix in place. Also tested manually against actual monarch money API to verify fix works with real endpoints (script not included).

Here's a place in [gql 4.0.0 release notes](https://github.com/graphql-python/gql/releases/tag/v4.0.0) where they mention the breaking change causing this issue:
> ALL the execute and subscribe methods now receive a GraphQLRequest as main argument instead of
a DocumentNode, variable_values and operation_name arguments

Note - I'm new to PRs on github / open source, please let me know if you need me to do anything else to help get this merged!