### PR TITLE
fix api domain: monarchmoney.com → monarch.com

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -24,7 +24,7 @@ SESSION_FILE = f"{SESSION_DIR}/mm_session.pickle"
 
 
 class MonarchMoneyEndpoints(object):
-    BASE_URL = "https://api.monarchmoney.com"
+    BASE_URL = "https://api.monarch.com"
 
     @classmethod
     def getLoginEndpoint(cls) -> str:


### PR DESCRIPTION
## what

one-line fix: updates `BASE_URL` from `api.monarchmoney.com` to `api.monarch.com`

the old domain returns HTTP 525 (SSL error) on all requests. the new domain works correctly

## why

the monarch money API moved domains. confirmed with curl:
- `curl -sI https://api.monarchmoney.com/graphql` → 525
- `curl -sI https://api.monarch.com/graphql` → 401 (expected, needs auth)

fixes #184

## testing

verified end-to-end: login + MFA + get_accounts() returns expected data with the new domain

all 8 existing unit tests pass

### AI Assistance
tools: Claude Code (find + replace, testing)
human review: full diff review, verified fix against production API